### PR TITLE
Fix branch-protection issues

### DIFF
--- a/plugins/module_utils/github.py
+++ b/plugins/module_utils/github.py
@@ -534,12 +534,14 @@ class GitHubBase(GitBase):
     def update_branch_protection(self, owner, repo, branch, target):
         """Set branch protection rules"""
         # Checks takes precedence as being more fine granular
-        checks = target.get('required_status_checks', {}).get('checks', '')
-        contexts = target.get('required_status_checks', {}).get('contexts', [])
-        if checks:
-            target['required_status_checks'].pop('contexts', '')
-        elif contexts:
-            target['required_status_checks'].pop('checks', '')
+        required_status_checks = target.get('required_status_checks', {})
+        if required_status_checks:
+            checks = required_status_checks.get('checks', '')
+            contexts = required_status_checks.get('contexts', [])
+            if checks:
+                target['required_status_checks'].pop('contexts', '')
+            elif contexts:
+                target['required_status_checks'].pop('checks', '')
 
         self.request(
             method='PUT',

--- a/plugins/modules/repositories.py
+++ b/plugins/modules/repositories.py
@@ -70,27 +70,32 @@ class Repo(GitHubBase):
                 ):
                     return True
 
-            current_restrictions = current.get('restrictions')
-            target_restrictions = target.get('restrictions')
-            current_pr_review = current.get('required_pull_request_reviews')
-            target_pr_review = target.get('required_pull_request_reviews')
+            current_restrictions = current.get('restrictions', {})
+            target_restrictions = target.get('restrictions', {})
+            current_pr_review = current.get('required_pull_request_reviews', {})
+            target_pr_review = target.get('required_pull_request_reviews', {})
             current_status_checks = current.get('required_status_checks', {})
             target_status_checks = target.get('required_status_checks', {})
-            if (current_status_checks.get(
-                'strict', False) != target_status_checks.get(
-                    'strict', False)):
-                return True
+            if target_status_checks:
+                if not current_status_checks:
+                    return True
+                if (current_status_checks.get(
+                    'strict', False) != target_status_checks.get(
+                        'strict', False)):
+                    return True
 
-            if (
-                set(
-                    current_status_checks.get('contexts', [])
-                ) != set(
-                    target_status_checks.get('contexts', [])
-                )
-            ):
-                return True
+                if (
+                    set(
+                        current_status_checks.get('contexts', [])
+                    ) != set(
+                        target_status_checks.get('contexts', [])
+                    )
+                ):
+                    return True
 
             if target_restrictions:
+                if not current_restrictions:
+                    return True
                 if (
                     set(
                         [x['login'] for x in current_restrictions['users']]


### PR DESCRIPTION
It is possible to set required_status_checks or restrictions to null if
these are not needed. Avoid failures when this happens.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>